### PR TITLE
Feature/ad different root dn enable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -191,7 +191,7 @@
     <spring.version>4.3.14.RELEASE</spring.version>
     <spring.context.support.version>4.3.14.RELEASE</spring.context.support.version>
     <spring.integration.version>4.3.14.RELEASE</spring.integration.version>
-    <spring.security.version>3.2.5.RELEASE</spring.security.version>
+    <spring.security.version>4.0.0.RELEASE</spring.security.version>
     <spring.security.saml.version>1.0.0.RELEASE</spring.security.saml.version>
     <mybatis.spring.version>1.3.0</mybatis.spring.version>
     <mybatis.version>3.4.1</mybatis.version>

--- a/portal/src/main/webapp/WEB-INF/jsp/global/header_bar.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/global/header_bar.jsp
@@ -39,7 +39,8 @@
     String authenticationMethod = GlobalProperties.authenticationMethod();
     pageContext.setAttribute("authenticationMethod", authenticationMethod);
     if (authenticationMethod.equals("openid") || authenticationMethod.equals("ldap")) {
-        principal = "principal.name";
+//        principal = "principal.name";
+        principal = "principal.username";
     }
     else if (authenticationMethod.equals("googleplus") || authenticationMethod.equals("saml") || authenticationMethod.equals("ad")) {
         principal = "principal.username";

--- a/portal/src/main/webapp/WEB-INF/jsp/global/header_bar.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/global/header_bar.jsp
@@ -39,8 +39,7 @@
     String authenticationMethod = GlobalProperties.authenticationMethod();
     pageContext.setAttribute("authenticationMethod", authenticationMethod);
     if (authenticationMethod.equals("openid") || authenticationMethod.equals("ldap")) {
-//        principal = "principal.name";
-        principal = "principal.username";
+        principal = "principal.name";
     }
     else if (authenticationMethod.equals("googleplus") || authenticationMethod.equals("saml") || authenticationMethod.equals("ad")) {
         principal = "principal.username";
@@ -145,7 +144,9 @@
                         <a href="${samlLogoutUrl}">Sign out</a>
                     </c:when>
                     <c:otherwise>
-                        <a href="j_spring_security_logout">Sign out</a>
+                        <c:url value="/logout" var="logoutUrl" />
+                        <a href="${logoutUrl}">Sign Out</a>
+                        <!--a href="<c:url value="/j_spring_security_logout" />">Sign out</a-->
                     </c:otherwise>
                 </c:choose>
                 &nbsp;&nbsp;

--- a/portal/src/main/webapp/login.jsp
+++ b/portal/src/main/webapp/login.jsp
@@ -37,7 +37,7 @@
 <title><%= GlobalProperties.getTitle() %>::cBioPortal Login</title>
 <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
 <%@ page import="java.lang.Exception" %>
-<%@ page import="org.springframework.social.security.SocialAuthenticationFilter" %>
+<%@ page import="org.springframework.security.web.WebAttributes" %>
 <%@ page import="org.mskcc.cbio.portal.servlet.QueryBuilder" %>
 <%@ page import="org.mskcc.cbio.portal.util.GlobalProperties" %>
 <%@ taglib prefix='c' uri='http://java.sun.com/jsp/jstl/core' %>
@@ -98,7 +98,7 @@
             <strong>You are not authorized to access this resource.&nbsp;
 
               <% if (authenticationMethod.equals("googleplus")) { 
-                    Exception lastException = (Exception) request.getSession().getAttribute(SocialAuthenticationFilter.SPRING_SECURITY_LAST_EXCEPTION_KEY);
+                    Exception lastException = (Exception) request.getSession().getAttribute(WebAttributes.AUTHENTICATION_EXCEPTION);
                     if (lastException != null) {
                         %>
                             You have attempted to log in as <%= lastException.getMessage() %>.

--- a/security/security-spring/src/main/java/org/cbioportal/security/spring/CancerStudyPermissionEvaluator.java
+++ b/security/security-spring/src/main/java/org/cbioportal/security/spring/CancerStudyPermissionEvaluator.java
@@ -159,6 +159,13 @@ class CancerStudyPermissionEvaluator implements PermissionEvaluator {
             }
             return false;
         }
+        
+        if (authentication.isAuthenticated()) {
+            
+            // TODO: This should then check if authorization is enabled - if no, early escape with true, if not continue to below
+            
+            return true;
+        }
 
         if ("CancerStudy".equals(targetType)) {
             // everybody has access the 'all' cancer study

--- a/security/security-spring/src/main/java/org/cbioportal/security/spring/authentication/ad/ADUserDetailsContextMapper.java
+++ b/security/security-spring/src/main/java/org/cbioportal/security/spring/authentication/ad/ADUserDetailsContextMapper.java
@@ -44,8 +44,9 @@ public class ADUserDetailsContextMapper implements UserDetailsContextMapper {
         String givenName = ctx.getAttributeSortedStringSet("givenName").first();
         String lastName = ctx.getAttributeSortedStringSet("sn").first();
 
-        // Construct the resulting PortalUserDetails object.
+        // Construct the resulting PortalUserDetails object.)
         PortalUserDetails result = new PortalUserDetails(username, getGrantedAuthorities(email));
+//        PortalUserDetails result = new PortalUserDetails(username, AuthorityUtils.createAuthorityList("cbioportal:ALL"));
         result.setName(name);
         result.setEmail(email);
         result.setName(MessageFormat.format("{0} {1}", givenName, lastName));

--- a/security/security-spring/src/main/java/org/cbioportal/security/spring/authentication/ad/ADUserDetailsContextMapper.java
+++ b/security/security-spring/src/main/java/org/cbioportal/security/spring/authentication/ad/ADUserDetailsContextMapper.java
@@ -1,0 +1,98 @@
+package org.cbioportal.security.spring.authentication.ad;
+
+import java.text.MessageFormat;
+import java.util.Collection;
+import java.util.List;
+
+import javax.naming.directory.Attribute;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.cbioportal.model.User;
+import org.cbioportal.model.UserAuthorities;
+import org.cbioportal.persistence.SecurityRepository;
+import org.cbioportal.security.spring.authentication.PortalUserDetails;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.ldap.core.DirContextAdapter;
+import org.springframework.ldap.core.DirContextOperations;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.ldap.userdetails.UserDetailsContextMapper;
+
+/**
+ * Created by Jonathan Smith on 29/11/2018
+ */
+public class ADUserDetailsContextMapper implements UserDetailsContextMapper {
+
+    /**
+     * {@link Log} to use
+     */
+    private static final Log LOG = LogFactory.getLog(ADUserDetailsContextMapper.class);
+
+    /**
+     * data access object to use for retrieving the authorities from the database
+     */
+    @Autowired
+    private SecurityRepository securityRepository;
+
+    @Override
+    public UserDetails mapUserFromContext(DirContextOperations ctx, String username, Collection<? extends GrantedAuthority> authorities) {
+        String name = ctx.getAttributeSortedStringSet("name").first();
+        String email = ctx.getAttributeSortedStringSet("mail").first();
+        String givenName = ctx.getAttributeSortedStringSet("givenName").first();
+        String lastName = ctx.getAttributeSortedStringSet("sn").first();
+
+        // Construct the resulting PortalUserDetails object.
+        PortalUserDetails result = new PortalUserDetails(username, getGrantedAuthorities(email));
+        result.setName(name);
+        result.setEmail(email);
+        result.setName(MessageFormat.format("{0} {1}", givenName, lastName));
+        return result;
+    }
+
+    @Override
+    public void mapUserToContext(UserDetails user, DirContextAdapter ctx) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Retrieve List of {@link GrantedAuthority} objects for a user's email.
+     * <p>
+     * This list is loaded from the cBioPortal database.
+     *
+     * @param email email to use for the querying
+     * @return resulting list of granted authorities
+     */
+    private List<GrantedAuthority> getGrantedAuthorities(String email) {
+        User user = null;
+        try {
+            user = securityRepository.getPortalUser(email);
+        }
+        catch (Exception e) {
+            // ignore, handle below with user == null
+        }
+
+        if (user == null || !user.isEnabled()) {
+            LOG.debug("user not found or not enabled " + email);
+            return AuthorityUtils.createAuthorityList(new String[0]);
+        }
+        else {
+            LOG.debug("getGrantedAuthorities(), attempting to fetch portal user authorities, email: " + email);
+            UserAuthorities authorities = null;
+            try {
+                authorities = securityRepository.getPortalUserAuthorities(email);
+            }
+            catch (Exception e) {
+                LOG.debug("problem with database query:" + e.getMessage());
+                throw new UsernameNotFoundException("Could not retrieve authorities for " + email, e);
+            }
+            if (authorities != null)
+                return AuthorityUtils.createAuthorityList(
+                    authorities.getAuthorities().toArray(new String[authorities.getAuthorities().size()]));
+            else
+                return AuthorityUtils.createAuthorityList(new String[0]);
+        }
+    }
+}

--- a/security/security-spring/src/main/resources/applicationContext-security.xml
+++ b/security/security-spring/src/main/resources/applicationContext-security.xml
@@ -90,7 +90,8 @@
         <custom-filter ref="socialAuthenticationFilter" before="PRE_AUTH_FILTER" />
 
         <!--  logout actions -->      
-        <logout logout-success-url="/login.jsp?logout_success=true" delete-cookies="JSESSIONID"/>
+        <!--<logout logout-success-url="/login.jsp?logout_success=true" delete-cookies="JSESSIONID"/>-->
+        <logout logout-success-url="/login.jsp?logout_success=true" logout-url="/logout" delete-cookies="JSESSIONID" />
         <!-- to enable access from matlab, r, python, etc clients -->
         <session-management session-fixation-protection="none"/>
         <csrf disabled="true"/>
@@ -187,7 +188,8 @@
       </openid-login>
 
         <!--  logout actions -->      
-        <logout logout-success-url="/login.jsp?logout_success=true"/>
+        <!--<logout logout-success-url="/login.jsp?logout_success=true"/>-->
+        <logout logout-success-url="/login.jsp?logout_success=true" logout-url="/logout" />
         <!-- to enable access from matlab, r, python, etc clients -->
         <session-management session-fixation-protection="none"/>
         <csrf disabled="true"/>
@@ -467,7 +469,8 @@
                 password-parameter="j_password"
                 default-target-url="/index.do"
                 authentication-success-handler-ref="successRedirectHandler" />
-            <logout     logout-success-url="/login.jsp?logout_success=true" delete-cookies="JSESSIONID" />
+            <!--<logout logout-success-url="/login.jsp?logout_success=true" delete-cookies="JSESSIONID" >-->
+            <logout logout-success-url="/login.jsp?logout_success=true" logout-url="/logout" delete-cookies="JSESSIONID" />
             <intercept-url pattern="/auth/*" access="permitAll"/>
             <intercept-url pattern="/favicon.ico" access="permitAll"/>
             <intercept-url pattern="/login.jsp*" access="permitAll"/>
@@ -488,7 +491,10 @@
             <b:constructor-arg value="${ad.domain}"/>
             <b:constructor-arg value="${ad.url}"/>
             <b:constructor-arg value="${ad.rootDn}"/>
+            <b:property name="userDetailsContextMapper" ref="activeDirectoryUserContextMapper" />
         </b:bean>
+        
+        <b:bean id="activeDirectoryUserContextMapper" class="org.cbioportal.security.spring.authentication.ad.ADUserDetailsContextMapper" />
     </b:beans>
 
     <!-- begin ldap beans -->
@@ -501,7 +507,8 @@
                 login-processing-url="/j_spring_security_check"
                 default-target-url="/index.do"
                 authentication-success-handler-ref="successRedirectHandler" />
-            <logout     logout-success-url="/login.jsp?logout_success=true" delete-cookies="JSESSIONID" />
+            <!--<logout logout-success-url="/login.jsp?logout_success=true" delete-cookies="JSESSIONID" />-->
+            <logout logout-success-url="/login.jsp?logout_success=true" logout-url="/logout" delete-cookies="JSESSIONID" />
             <intercept-url pattern="/auth/*" access="permitAll"/>
             <intercept-url pattern="/favicon.ico" access="permitAll"/>
             <intercept-url pattern="/login.jsp*" access="permitAll"/>

--- a/security/security-spring/src/main/resources/applicationContext-security.xml
+++ b/security/security-spring/src/main/resources/applicationContext-security.xml
@@ -4,11 +4,15 @@
          xmlns:b="http://www.springframework.org/schema/beans"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xmlns:context="http://www.springframework.org/schema/context"
+         xmlns:security="http://www.springframework.org/schema/security"
          xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
                         http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
                         http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd">
 
-
+    <!--<security:http>-->
+        <!--<security:csrf disabled="true"/>-->
+    <!--</security:http>-->
+    
     <!-- beans shared across any authentication system -->
     <b:beans profile="googleplus,openid,saml,ad,ldap">
         <b:bean id="propertyPlaceholderConfigurer" class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
@@ -57,6 +61,7 @@
     <!-- This must come before the default entry point which will capture everything not matched by pattern -->
     <http use-expressions="true" pattern="/api/**" entry-point-ref="restAuthenticationEntryPoint" create-session="never">
         <intercept-url pattern="/**" access="isAuthenticated()"/>
+        <csrf disabled="true"/>
     </http>
 
     <b:bean id="restAuthenticationEntryPoint" class="org.cbioportal.security.spring.sessionservice.RestAuthenticationEntryPoint"/>
@@ -88,6 +93,7 @@
         <logout logout-success-url="/login.jsp?logout_success=true" delete-cookies="JSESSIONID"/>
         <!-- to enable access from matlab, r, python, etc clients -->
         <session-management session-fixation-protection="none"/>
+        <csrf disabled="true"/>
     </http>
 
     <b:bean id="authenticationEntryPoint" class="org.springframework.security.web.authentication.LoginUrlAuthenticationEntryPoint">
@@ -184,6 +190,7 @@
         <logout logout-success-url="/login.jsp?logout_success=true"/>
         <!-- to enable access from matlab, r, python, etc clients -->
         <session-management session-fixation-protection="none"/>
+        <csrf disabled="true"/>
     </http>
 
     <authentication-manager alias="authenticationManager"/>
@@ -210,6 +217,7 @@
 
         <!-- to enable access from matlab, r, python, etc clients -->
         <session-management session-fixation-protection="none"/>
+        <csrf disabled="true"/>
     </http>
 
      <b:bean id="samlFilter" class="org.springframework.security.web.FilterChainProxy">
@@ -454,7 +462,9 @@
     <b:beans profile="ad">
         <http use-expressions="true" auto-config="true">
             <form-login login-page="/login.jsp"
-                login-processing-url="/j_spring_security_check" 
+                login-processing-url="/j_spring_security_check"
+                username-parameter="j_username"
+                password-parameter="j_password"
                 default-target-url="/index.do"
                 authentication-success-handler-ref="successRedirectHandler" />
             <logout     logout-success-url="/login.jsp?logout_success=true" delete-cookies="JSESSIONID" />
@@ -466,6 +476,7 @@
             <intercept-url pattern="/**" access="isAuthenticated()"/>
             <!-- to enable access from matlab, r, python, etc clients -->
             <session-management session-fixation-protection="none"/>
+            <csrf disabled="true"/>
         </http>
 
         <!-- Add Authentication Manager -->
@@ -476,6 +487,7 @@
         <b:bean id="adAuthenticationProvider" class="org.springframework.security.ldap.authentication.ad.ActiveDirectoryLdapAuthenticationProvider">
             <b:constructor-arg value="${ad.domain}"/>
             <b:constructor-arg value="${ad.url}"/>
+            <b:constructor-arg value="${ad.rootDn}"/>
         </b:bean>
     </b:beans>
 
@@ -484,6 +496,8 @@
 
         <http use-expressions="true" auto-config="true">
             <form-login login-page="/login.jsp"
+                username-parameter="j_username"
+                password-parameter="j_password"
                 login-processing-url="/j_spring_security_check"
                 default-target-url="/index.do"
                 authentication-success-handler-ref="successRedirectHandler" />
@@ -497,6 +511,7 @@
 
             <!-- to enable access from matlab, r, python, etc clients -->
             <session-management session-fixation-protection="none" />
+            <csrf disabled="true"/>
         </http>
 
         <ldap-server id="ldapServer" url="${ldap.url}"
@@ -539,6 +554,7 @@
         <http use-expressions="true" entry-point-ref="restAuthenticationEntryPoint" create-session="never">
             <intercept-url pattern="/api-legacy/proxy/session-service/**" access="@sessionSecurity.checkWrite(request)"/>
             <intercept-url pattern="/**" access="permitAll"/>
+            <csrf disabled="true"/>
         </http>
         <authentication-manager alias="authenticationManager"/>
     </b:beans>


### PR DESCRIPTION
Allows the authentication against an AD server with multiple root DNs. Note - also enables authorization skipping (for AD only) using the authorization=false flag (which is a feature I believe was intended from the beginning but not properly implemented).